### PR TITLE
Add type checking with flow

### DIFF
--- a/src/__tests__/index.browser.js
+++ b/src/__tests__/index.browser.js
@@ -52,7 +52,8 @@ tape('provides theme', async t => {
 
   t.plan(2);
 
-  t.equals(serviceWithTheme.from(ctx).theme.foo, 'bar', 'passes along theme');
+  const theme: any = serviceWithTheme.from(ctx).theme;
+  t.equals(theme.foo, 'bar', 'passes along theme');
   t.notEqual(
     serviceWithoutTheme.from(ctx).theme,
     null,
@@ -66,6 +67,9 @@ tape('removes useless SSR styles after render', async t => {
   const ssrStyles = document.createElement('style');
   ssrStyles.setAttribute('type', 'text/css');
   ssrStyles.setAttribute('id', '__MUI_STYLES__');
+  if (!(document.body instanceof HTMLElement)) {
+    return t.fail();
+  }
   document.body.appendChild(ssrStyles);
   const element = React.createElement('div');
   const ctx: any = {element, template: {body: []}, memoized: new Map()};

--- a/src/__tests__/index.node.js
+++ b/src/__tests__/index.node.js
@@ -31,7 +31,7 @@ tape('provides a custom jss instance', async t => {
   t.equals(service.from(ctx).jss, testJss, 'passes along the jss instance');
 
   t.end();
-})
+});
 
 tape('provides theme', async t => {
   const element = React.createElement('div');
@@ -41,12 +41,11 @@ tape('provides theme', async t => {
 
   t.plan(2);
 
-  t.equals(serviceWithTheme.from(ctx).theme.foo, 'bar', 'passes along theme');
-  t.notEqual(
-    serviceWithoutTheme.from(ctx).theme.spacing.unit,
-    null,
-    'but has a default theme'
-  );
+  const withTheme: any = serviceWithTheme.from(ctx).theme;
+  const withoutTheme: any = serviceWithoutTheme.from(ctx).theme;
+
+  t.equals(withTheme.foo, 'bar', 'passes along theme');
+  t.notEqual(withoutTheme.spacing.unit, null, 'but has a default theme');
 
   t.end();
 });
@@ -62,6 +61,7 @@ tape('serialization', async t => {
   await Plugin.middleware(null, service)(ctx, () => Promise.resolve());
   t.equals(ctx.template.body.length, 1, 'pushes serialization to body');
   t.equals(
+    // $FlowFixMe
     consumeSanitizedHTML(ctx.template.body[0]).match('</style>').input,
     '<style type="text/css" id="__MUI_STYLES__"></style>'
   );

--- a/src/browser.js
+++ b/src/browser.js
@@ -6,17 +6,25 @@ import JssProvider from 'react-jss/lib/JssProvider';
 import {MuiThemeProvider, createMuiTheme} from '@material-ui/core/styles';
 import {MuiThemeToken, JssToken} from './tokens';
 
+import type {Context, FusionPlugin} from 'fusion-core';
+import type {MaterialUIDepsType, MaterialUIServiceType} from './types.js';
+
 const plugin =
   __BROWSER__ &&
   createPlugin({
     deps: {theme: MuiThemeToken.optional, jss: JssToken.optional},
     provides({jss, theme}) {
-      class MuiService {
+      class MuiService<T> {
         constructor(ctx) {
           this.ctx = ctx;
           this.jss = jss;
           this.theme = theme ? theme : createMuiTheme();
         }
+
+        // TODO: More specific types
+        theme: T;
+        ctx: Context;
+        jss: mixed;
       }
       return {
         from: memoize(ctx => new MuiService(ctx)),
@@ -46,4 +54,7 @@ const plugin =
     },
   });
 
-export default plugin;
+export default ((plugin: any): FusionPlugin<
+  MaterialUIDepsType,
+  MaterialUIServiceType
+>);

--- a/src/server.js
+++ b/src/server.js
@@ -1,5 +1,6 @@
 // @flow
 /* eslint-env node */
+
 import React from 'react';
 import {createPlugin, html, memoize} from 'fusion-core';
 import defaultJss, {SheetsRegistry} from 'react-jss/lib/jss';
@@ -9,18 +10,27 @@ import {MuiThemeToken, JssToken} from './tokens';
 import autoprefixer from 'autoprefixer';
 import postcss from 'postcss';
 
+import type {Context, FusionPlugin} from 'fusion-core';
+import type {MaterialUIDepsType, MaterialUIServiceType} from './types.js';
+
 const plugin =
   __NODE__ &&
   createPlugin({
     deps: {theme: MuiThemeToken.optional, jss: JssToken.optional},
     provides({jss, theme}) {
-      class MuiService {
+      class MuiService<T> {
         constructor(ctx) {
           this.sheetsRegistry = new SheetsRegistry();
           this.ctx = ctx;
           this.jss = jss ? jss : defaultJss;
           this.theme = theme ? theme : createMuiTheme();
         }
+
+        // TODO: More specific types
+        theme: T;
+        ctx: Context;
+        sheetsRegistry: mixed;
+        jss: mixed;
       }
       return {
         from: memoize(ctx => new MuiService(ctx)),
@@ -29,7 +39,7 @@ const plugin =
     middleware(_, muiService) {
       return async (ctx, next) => {
         if (!ctx.element) return next();
-        const {jss, sheetsRegistry, theme} = await muiService.from(ctx);
+        const {jss, sheetsRegistry, theme} = muiService.from(ctx);
 
         ctx.element = (
           <JssProvider jss={jss} registry={sheetsRegistry}>
@@ -42,6 +52,7 @@ const plugin =
         await next();
 
         const serialized = await postcss([autoprefixer]).process(
+          // $FlowFixMe
           sheetsRegistry.toString()
         );
         const styles = html`<style type="text/css" id="__MUI_STYLES__">${serialized}</style>`;
@@ -50,4 +61,7 @@ const plugin =
     },
   });
 
-export default plugin;
+export default ((plugin: any): FusionPlugin<
+  MaterialUIDepsType,
+  MaterialUIServiceType
+>);

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -1,5 +1,11 @@
-import {createToken} from 'fusion-core';
+// @flow
 
-export const MuiThemeToken = createToken('MuiThemeToken');
-export const MuiThemeProviderToken = createToken('MuiThemeProviderToken');
-export const JssToken = createToken('JssToken');
+import {createToken} from 'fusion-core';
+import type {Token} from 'fusion-core';
+
+// TODO: More specific types
+export const MuiThemeToken: Token<any> = createToken('MuiThemeToken');
+export const MuiThemeProviderToken: Token<any> = createToken(
+  'MuiThemeProviderToken'
+);
+export const JssToken: Token<any> = createToken('JssToken');

--- a/src/types.js
+++ b/src/types.js
@@ -1,0 +1,23 @@
+// @flow
+
+import {MuiThemeToken, JssToken} from './tokens.js';
+
+import type {Context} from 'fusion-core';
+
+export type MaterialUIDepsType = {
+  theme: typeof MuiThemeToken.optional,
+  jss: JssToken.optional,
+};
+
+export type MaterialUIServiceType = {
+  from: (
+    ctx?: Context
+  ) => {
+    ctx?: Context,
+    // TODO: More specific types
+    theme: mixed,
+    ctx: Context,
+    sheetsRegistry: mixed,
+    jss: mixed,
+  },
+};


### PR DESCRIPTION
Fusion.js core plugins currently leverage flow for type safety. This helps detect errors during buildtime and avoids runtime errors. Adding flow typing to server and browser exports will enable applications to use this, with some form of type safety.

Note: these types aren't super accurate yet, but we can work on improving them over time.