### PR TITLE
DRY up the middleware and provider

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -1,57 +1,23 @@
 // @flow
 /* eslint-env browser */
-import React from 'react';
-import defaultJss, {SheetsRegistry} from 'react-jss/lib/jss';
-import {createPlugin, memoize} from 'fusion-core';
-import JssProvider from 'react-jss/lib/JssProvider';
-import {MuiThemeProvider, createMuiTheme} from '@material-ui/core/styles';
+import {createPlugin} from 'fusion-core';
 import {MuiThemeToken, JssToken} from './tokens';
+import {addProviders} from './middleware';
+import {provides} from './provider';
 
-import type {Context, FusionPlugin} from 'fusion-core';
+import type {FusionPlugin} from 'fusion-core';
 import type {MaterialUIDepsType, MaterialUIServiceType} from './types.js';
 
 const plugin =
   __BROWSER__ &&
   createPlugin({
     deps: {theme: MuiThemeToken.optional, jss: JssToken.optional},
-    provides({jss, theme}) {
-      class MuiService<T> {
-        constructor(ctx) {
-          this.ctx = ctx;
-          this.sheetsRegistry = new SheetsRegistry();
-          this.jss = jss ? jss : defaultJss;
-          this.theme = theme ? theme : createMuiTheme();
-        }
-
-        // TODO: More specific types
-        theme: T;
-        ctx: Context;
-        sheetsRegistry: mixed;
-        jss: mixed;
-      }
-      return {
-        from: memoize(ctx => new MuiService(ctx)),
-      };
-    },
+    provides,
     middleware(_, muiService) {
       return async (ctx, next) => {
         if (!ctx.element) return next();
 
-        const {jss, sheetsRegistry, theme} = await muiService.from(ctx);
-
-        ctx.element = (
-          <MuiThemeProvider theme={theme} sheetsManager={new Map()}>
-            {ctx.element}
-          </MuiThemeProvider>
-        );
-
-        if (jss) {
-          ctx.element = (
-            <JssProvider jss={jss} registry={sheetsRegistry}>
-              {ctx.element}
-            </JssProvider>
-          );
-        }
+        ctx.element = await addProviders(ctx, muiService);
 
         await next();
 

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,0 +1,17 @@
+// @flow
+import React from 'react';
+
+import JssProvider from 'react-jss/lib/JssProvider';
+import {MuiThemeProvider} from '@material-ui/core/styles';
+
+export const addProviders = async (ctx, muiService) => {
+  const {jss, sheetsRegistry, theme} = await muiService.from(ctx);
+
+  return (
+    <JssProvider jss={jss} registry={sheetsRegistry}>
+      <MuiThemeProvider theme={theme} sheetsManager={new Map()}>
+        {ctx.element}
+      </MuiThemeProvider>
+    </JssProvider>
+  );
+}

--- a/src/provider.js
+++ b/src/provider.js
@@ -1,0 +1,34 @@
+// @flow
+import {memoize} from 'fusion-core';
+import {SheetsRegistry} from 'react-jss/lib/jss';
+import {create as createJss} from 'jss';
+import {createMuiTheme, jssPreset} from '@material-ui/core/styles';
+
+import type {Context} from 'fusion-core';
+
+console.log(jssPreset);
+
+export const provides = ({jss, theme}) => {
+  class MuiService<T> {
+    constructor(ctx) {
+      this.ctx = ctx;
+      this.sheetsRegistry = new SheetsRegistry();
+      this.theme = theme ? theme : createMuiTheme();
+      if (jss) {
+        this.jss = jss;
+      } else {
+        this.jss = createJss();
+        this.jss.setup(jssPreset);
+      }
+    }
+
+    // TODO: More specific types
+    theme: T;
+    ctx: Context;
+    sheetsRegistry: mixed;
+    jss: mixed;
+  }
+  return {
+    from: memoize(ctx => new MuiService(ctx)),
+  };
+};


### PR DESCRIPTION
abstracted the `provides` function and the majority of the `middleware` logic

additionally changed the `jss` instance we use if none is provided, it now creates a fresh `jss` and installs the `jssPreset` from `material-ui`

this should make everything more consistent between client and server